### PR TITLE
Fix baseline export click handler

### DIFF
--- a/src/components/BaselineManager.svelte
+++ b/src/components/BaselineManager.svelte
@@ -82,7 +82,7 @@
         </button>
         <button
         class="text-sm text-nord-10 hover:text-nord-9 underline transition"
-        on:click={exportBaselineAsJSON(b)}
+        on:click={() => exportBaselineAsJSON(b)}
       >
         Export
       </button>


### PR DESCRIPTION
## Summary
- fix BaselineManager export button handler so export only happens on click

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e08c9d3c832c885a173cb2ed9cac