### PR TITLE
Fix library import trigger name

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -152,7 +152,7 @@
   // Used to handle library file upload
   let libraryFileInput;
 
-  function triggerimportLibraryFromJSON() {
+  function triggerImportLibraryFromJSON() {
     libraryFileInput.click();
   }
 
@@ -258,7 +258,7 @@
     <ActionButton
       label="Import library"
       icon={FolderUp}
-      onClick={triggerimportLibraryFromJSON}
+      onClick={triggerImportLibraryFromJSON}
     />
   </div>
 


### PR DESCRIPTION
## Summary
- rename the function that triggers a library import file input
- update the import-library button handler

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e0594cd4832cb3933684264f1f85