### PR TITLE
Fix bullet label in baseline helper

### DIFF
--- a/src/components/BaselineHelperModal.svelte
+++ b/src/components/BaselineHelperModal.svelte
@@ -17,7 +17,7 @@
         <ul class="list-disc list-inside text-sm mb-4">
           <li><strong>CR</strong> — the challenge rating (e.g. 1, 2, 5)</li>
           <li><strong>DPR</strong> — used in <code>dpaFormula</code>, damage per round</li>
-          <li><strong>DPR</strong> — used in <code>dpaFormula</code>, number of attacks</li>
+          <li><strong>NOA</strong> — used in <code>dpaFormula</code>, number of attacks</li>
         </ul>
         <h4 class="font-semibold mb-1">Examples:</h4>
         <ul class="text-sm mb-4">


### PR DESCRIPTION
## Summary
- fix copy in the How to Write Formulas section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841e00af47c832ca038080d5c45bf9e